### PR TITLE
Skip unsupported SOP Classes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dicom-send",
   "label": "DCMTK: DICOM Send - storescu",
   "description": "The DICOM Send Gear uses DCMTK storescu to send DICOM data from a Flywheel instance to a DICOM server. The DICOM server must be reachable from the host of the Flywheel instance.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "inputs": {
     "file": {
       "base": "file",
@@ -44,7 +44,7 @@
   "source": "https://flywheel.io",
   "url": "http://support.dcmtk.org/docs/storescu.html",
   "custom": {
-    "docker-image": "flywheel/dicom-send:0.12.0"
+    "docker-image": "flywheel/dicom-send:0.13.0"
   },
   "flywheel": {
     "suite": "DCMTK"

--- a/run
+++ b/run
@@ -57,6 +57,8 @@ if [[  -z "$input_file" ]] ; then
   python download_dicoms.py --api-key "${api_key}" --session "${config_session_id}" --input_dir "${INPUT_DIR}/file"
 fi
 
+dicoms_sent=0
+
 for input_file in $INPUT_DIR/file/*; do
   # Prepare inputs: unzip, gunzip, or uncompressed
   if [[ "$input_file" == *.zip ]] ; then
@@ -92,7 +94,7 @@ for input_file in $INPUT_DIR/file/*; do
     # or single .dcm file
 
     dicom_input=$INPUT_DIR
-    cp -a $input_file $INPUT_DIR
+    cp -a "$input_file" $INPUT_DIR
   fi
 
   ##############################################################################
@@ -108,18 +110,28 @@ for input_file in $INPUT_DIR/file/*; do
 
   ##############################################################################
   # Run the storescu algorithm passing ENV vars with config
-
-  storescu -v --scan-directories -aet "${config_calling_ae}" \
-    -aec "${config_called_ae}" \
-    "${config_destination}" \
-    "${config_port}" \
-    "${dicom_input}" \
+  if [[ -n `dcmdump --scan-directories "${dicom_input}" | grep "(0008,0016)" | grep "="` ]]; then
+    storescu -v --scan-directories -aet "${config_calling_ae}" \
+      -aec "${config_called_ae}" \
+      "${config_destination}" \
+      "${config_port}" \
+      "${dicom_input}"
+  else
+    echo "WARNING: Skipping ${input_file} of unknown SOPClassUID"
+  fi
 
   if [ $? -eq 0 ]; then
     echo OK
+    ((dicoms_sent++))
   else
     echo "FAIL: $input_file"
-    exit 1
   fi
 
 done
+
+if (( $dicoms_sent < 1 )); then
+  echo "ERROR: No dicoms sent!"
+  exit 1
+else
+  echo OK
+fi

--- a/run
+++ b/run
@@ -110,28 +110,34 @@ for input_file in $INPUT_DIR/file/*; do
 
   ##############################################################################
   # Run the storescu algorithm passing ENV vars with config
+
+  # Check if the SOPClassUID is recognized by dcmtk dcmdump
   if [[ -n `dcmdump --scan-directories "${dicom_input}" | grep "(0008,0016)" | grep "="` ]]; then
     storescu -v --scan-directories -aet "${config_calling_ae}" \
       -aec "${config_called_ae}" \
       "${config_destination}" \
       "${config_port}" \
       "${dicom_input}"
-  else
-    echo "WARNING: Skipping ${input_file} of unknown SOPClassUID"
-  fi
 
-  if [ $? -eq 0 ]; then
-    echo OK
-    ((dicoms_sent++))
+    # Check that strocescu succeeded
+    if [ $? -eq 0 ]; then
+      echo OK
+      ((dicoms_sent++))
+    else
+      echo "FAIL: $input_file"
+    fi
   else
-    echo "FAIL: $input_file"
+    # Skip if not recognized
+    echo "WARNING: Skipping ${input_file} of unknown SOPClassUID"
   fi
 
 done
 
+# Only Fail if no dicoms were sent
 if (( $dicoms_sent < 1 )); then
   echo "ERROR: No dicoms sent!"
   exit 1
 else
+  echo "INFO: Sent ${dicoms_sent} dicoms"
   echo OK
 fi


### PR DESCRIPTION
### Changes
- Checks the dcmdump if the SOPClassUID is represented as a string (meaning it is recognized by the dcmtk tool-kit) and if not, skips the dicom.
- If, at the end of the run script, at least one dicom was sent successfully, we exit successfully.