### PR TITLE
Use pydicom error to check if dicom instead of a string

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "dicom-send",
   "label": "DCMTK: DICOM Send - storescu",
   "description": "The DICOM Send Gear uses DCMTK storescu to send DICOM data from a Flywheel instance to a DICOM server. The DICOM server must be reachable from the host of the Flywheel instance.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "inputs": {
     "file": {
       "base": "file",
@@ -44,7 +44,7 @@
   "source": "https://flywheel.io",
   "url": "http://support.dcmtk.org/docs/storescu.html",
   "custom": {
-    "docker-image": "flywheel/dicom-send:0.14.0"
+    "docker-image": "flywheel/dicom-send:0.14.1"
   },
   "flywheel": {
     "suite": "DCMTK"

--- a/tagger.py
+++ b/tagger.py
@@ -38,8 +38,10 @@ def tag_image(file_path, group, identifier, tag_value):
 def tag_folder(dir_path, group, identifier, tag_value):
     tags = []
     for image_file in os.listdir(dir_path):
-        if '.dcm' in image_file:
+        try:
             tags.append(tag_image(os.path.join(dir_path, image_file), group, identifier, tag_value))
+        except pydicom.errors.InvalidDicomError:
+            continue
     return list(set(tags))
 
 
@@ -60,5 +62,7 @@ if __name__ == '__main__':
 
     if len(tags) > 1:
         print('WARNING: Tagged at different elements')
+    elif len(tags) == 0:
+        print('WARNING: No Dicoms were tagged!')
     else:
         print('INFO: Tagged at ({0:#x}, {1:#x})'.format(tags[0][0], tags[0][1]))


### PR DESCRIPTION
Dicoms can also have the .DCM extension instead of .dcm, so instead of using the filename, just let pydicom error and catch it when trying to tag all the dicoms.